### PR TITLE
Update localforage-indexes.js

### DIFF
--- a/lib/localforage-indexes.js
+++ b/lib/localforage-indexes.js
@@ -79,7 +79,7 @@ export function createIndex(indexName, keyPath, options, callback) {
 
                 resolve(_getIndex(localforageInstance, indexName));
             }
-        );
+        ).catch(function(err) {reject(err)});
     }, callback);
 }
 
@@ -130,7 +130,7 @@ export function updateIndex(indexName, keyPath, options, callback) {
 
                 resolve(_getIndex(localforageInstance, indexName));
             }
-        );
+        ).catch(function(err) {reject(err)});
     }, callback);
 }
 
@@ -159,7 +159,7 @@ export function deleteIndex(indexName, callback) {
 
                 resolve();
             }
-        );
+        ).catch(function(err) {reject(err)});
     }, callback);
 }
 


### PR DESCRIPTION
while setting up testing in an environment that does not support localStorage I discovered an unhandled rejection.  Adding these lines makes the rejection bubble up to my code where I can handle it.